### PR TITLE
ruby 2.5 compliant format strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,3 @@ source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
-
-gem 'colored2' 
-gem 'sidekiq' 
-gem 'dry-configurable'
-gem 'state_machines'
-

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
 
+gem 'colored2' 
+gem 'sidekiq' 
+gem 'dry-configurable'
+gem 'state_machines'
+

--- a/lib/sidekiq/cluster/worker.rb
+++ b/lib/sidekiq/cluster/worker.rb
@@ -64,7 +64,7 @@ module Sidekiq
 
       def memory_used_percent
         mem = memory_used_pct
-        mem < 0 ? 'DEAD' : sprintf('%.2f%', mem)
+        mem < 0 ? 'DEAD' : sprintf('%.2f%%', mem)
       end
 
       def check_worker

--- a/lib/sidekiq/cluster/worker_pool.rb
+++ b/lib/sidekiq/cluster/worker_pool.rb
@@ -99,6 +99,8 @@ module Sidekiq
         %w(INT USR1 TERM).each do |sig|
           Signal.trap(sig) do
             handle_signal(sig)
+            stop! if @signal_received
+            shutdown! if stopping?
           end
         end
       end

--- a/lib/sidekiq/cluster/worker_pool.rb
+++ b/lib/sidekiq/cluster/worker_pool.rb
@@ -96,7 +96,7 @@ module Sidekiq
       end
 
       def setup_signal_traps
-        %w(INT USR1 TERM).each do |sig|
+        %w(INT TSTP TTIN TERM).each do |sig|
           Signal.trap(sig) do
             handle_signal(sig)
             stop! if @signal_received

--- a/sidekiq-cluster.gemspec
+++ b/sidekiq-cluster.gemspec
@@ -1,14 +1,13 @@
 # coding: utf-8
-require_relative 'lib/sidekiq/cluster/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'sidekiq-cluster'
-  spec.version       = Sidekiq::Cluster::VERSION
+  spec.version       = '0.1.2'
   spec.authors       = ['Konstantin Gredeskoul']
   spec.email         = ['kigster@gmail.com']
 
-  spec.summary       = Sidekiq::Cluster::DESCRIPTION
-  spec.description   = Sidekiq::Cluster::DESCRIPTION
+  spec.summary       = 'Foo Bar'
+  spec.description   = 'Foo Bar'
   spec.homepage      = 'https://github.com/kigster/sidekiq-cluster'
   spec.license       = 'MIT'
 

--- a/sidekiq-cluster.gemspec
+++ b/sidekiq-cluster.gemspec
@@ -1,8 +1,5 @@
 # coding: utf-8
-
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'sidekiq/cluster/version'
+require_relative 'lib/sidekiq/cluster/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'sidekiq-cluster'


### PR DESCRIPTION
Avoids the following crash while exec with ruby 2.5:
```
#<Thread:0x00007fdbaf20ae08@/Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/monitors/base.rb:16 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	9: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/monitors/base.rb:16:in `block in start'
	8: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/monitors/oom.rb:9:in `monitor'
	7: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/monitors/oom.rb:9:in `loop'
	6: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/monitors/oom.rb:13:in `block in monitor'
	5: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/monitors/base.rb:32:in `log_periodically'
	4: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/monitors/oom.rb:14:in `block (2 levels) in monitor'
	3: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/monitors/oom.rb:14:in `map'
	2: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/worker.rb:109:in `status'
	1: from /Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/worker.rb:67:in `memory_used_percent'
/Users/victor/.rvm/gems/ruby-2.5.1/gems/sidekiq-cluster-0.1.2/lib/sidekiq/cluster/worker.rb:67:in `sprintf': incomplete format specifier; use %% (double %) instead (ArgumentError)
```